### PR TITLE
Add heartbeats output channel

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -23,6 +23,7 @@ type Database interface {
 	Changes(db string, req map[string]string) (*ChangesResponse, error)
 	//ChangesContinuous(db string, queryReq map[string]string, inCh chan *DbResult, quitCh chan struct{}) (chan *DbResult, chan<- struct{}, error)
 	ChangesContinuousRaw(db string, queryReq map[string]string, inCh chan *DbResult, quitCh chan struct{}) (chan *DbResult, chan<- struct{}, error)
+	ChangesContinuousRawWithHeartBeat(db string, queryReq map[string]string, inCh chan *DbResult, inHeartBeatCh chan *HeartBeatResult, quitCh chan struct{}) (chan *DbResult, chan *HeartBeatResult, chan<- struct{}, error)
 	ChangesContinuousBytes(db string, queryReq map[string]string) (*http.Response, error)
 	Compact(db string) (*OkKoResponse, error)
 	CompactDesignDoc(db string, ddoc string) (*OkKoResponse, error)
@@ -88,9 +89,9 @@ type AllDocsRequest struct {
 type AllDocsResponse struct {
 	ErrorResponse
 	Offset int `json:"offset"`
-	Rows   []struct {
-		ID    string `json:"id"`
-		Key   string `json:"key"`
+	Rows []struct {
+		ID  string `json:"id"`
+		Key string `json:"key"`
 		Value struct {
 			Rev string `json:"rev"`
 		} `json:"value"`
@@ -107,7 +108,7 @@ type BulkResponse []CreateDocumentResponse
 type FindRequest struct {
 	Selector map[string]interface{} `json:"selector"`
 	Fields   []string               `json:"fields"`
-	Sort     []struct {
+	Sort []struct {
 		Year string `json:"year"`
 	} `json:"sort"`
 	Limit int `json:"limit"`
@@ -135,11 +136,11 @@ type SetIndexResponse struct {
 type IndexResponse struct {
 	ErrorResponse
 	TotalRows int `json:"total_rows"`
-	Indexes   []struct {
+	Indexes []struct {
 		Ddoc interface{} `json:"ddoc"`
 		Name string      `json:"name"`
 		Type string      `json:"type"`
-		Def  struct {
+		Def struct {
 			Fields []struct {
 				ID string `json:"_id"`
 			} `json:"fields"`
@@ -150,11 +151,11 @@ type IndexResponse struct {
 type ExplainResponse struct {
 	ErrorResponse
 	Dbname string `json:"dbname"`
-	Index  struct {
+	Index struct {
 		Ddoc string `json:"ddoc"`
 		Name string `json:"name"`
 		Type string `json:"type"`
-		Def  struct {
+		Def struct {
 			Fields []struct {
 				Year string `json:"year"`
 			} `json:"fields"`
@@ -170,7 +171,7 @@ type ExplainResponse struct {
 		Bookmark string        `json:"bookmark"`
 		Limit    int           `json:"limit"`
 		Skip     int           `json:"skip"`
-		Sort     struct {
+		Sort struct {
 		} `json:"sort"`
 		Fields    []string `json:"fields"`
 		R         []int    `json:"r"`
@@ -179,9 +180,9 @@ type ExplainResponse struct {
 	Limit  int      `json:"limit"`
 	Skip   int      `json:"skip"`
 	Fields []string `json:"fields"`
-	Range  struct {
+	Range struct {
 		StartKey []int `json:"start_key"`
-		EndKey   []struct {
+		EndKey []struct {
 		} `json:"end_key"`
 	} `json:"range"`
 }
@@ -227,6 +228,8 @@ type Deleted struct {
 	Rev     string `json:"_rev"`
 }
 
+type HeartBeatResult struct{}
+
 type ChangesResponse struct {
 	ErrorResponse
 	LastSeq int         `json:"last_seq"`
@@ -257,7 +260,7 @@ type SecurityResponse struct {
 type DoPurgeResponse struct {
 	ErrorResponse
 	PurgeSeq int `json:"purge_seq"`
-	Purged   struct {
+	Purged struct {
 		C6114C65E295552Ab1019E2B046B10E []string `json:"c6114c65e295552ab1019e2b046b10e"`
 	} `json:"purged"`
 }

--- a/databases_http.go
+++ b/databases_http.go
@@ -105,7 +105,10 @@ func handleResult(lineByt []byte, out chan *DbResult, quit chan struct{}, db str
 	result.DbName = db
 
 	if err := json.Unmarshal(lineByt, &result); err != nil {
-		return
+		result.ErrorResponse = &ErrorResponse{
+			ErrorS: "Error parsing input",
+			Reason: err.Error(),
+		}
 	}
 
 	select {
@@ -141,7 +144,9 @@ func dbResultHandler(httpRes *http.Response, out chan *DbResult, quit chan struc
 
 	ln, err := Readln(reader)
 	for err == nil {
-		handleResult(ln, out, quit, db)
+		if len(ln) > 0 {
+			handleResult(ln, out, quit, db)
+		}
 		ln, err = Readln(reader)
 	}
 

--- a/databases_http.go
+++ b/databases_http.go
@@ -100,6 +100,14 @@ func (d *DatabasesClient) setAuth(r *http.Request) {
 	}
 }
 
+func handleHeartbeat(out chan *HeartBeatResult, quit chan struct{}) {
+	select {
+	case <-quit:
+		return
+	case out <- &HeartBeatResult{}:
+	}
+}
+
 func handleResult(lineByt []byte, out chan *DbResult, quit chan struct{}, db string) {
 	var result DbResult
 	result.DbName = db
@@ -136,7 +144,7 @@ func handleScannerErr(err error, out chan *DbResult, db string, quit chan struct
 	}
 }
 
-func dbResultHandler(httpRes *http.Response, out chan *DbResult, quit chan struct{}, db string) {
+func dbResultHandler(httpRes *http.Response, out chan *DbResult, outHeartbeat chan *HeartBeatResult, quit chan struct{}, db string) {
 	defer httpRes.Body.Close()
 
 	//Test
@@ -144,7 +152,9 @@ func dbResultHandler(httpRes *http.Response, out chan *DbResult, quit chan struc
 
 	ln, err := Readln(reader)
 	for err == nil {
-		if len(ln) > 0 {
+		if len(ln) == 0 {
+			handleHeartbeat(outHeartbeat, quit)
+		} else {
 			handleResult(ln, out, quit, db)
 		}
 		ln, err = Readln(reader)
@@ -155,6 +165,7 @@ func dbResultHandler(httpRes *http.Response, out chan *DbResult, quit chan struc
 	fmt.Println("Closing CouchDB client")
 
 	close(out)
+	close(outHeartbeat)
 	close(quit)
 }
 
@@ -203,8 +214,13 @@ func (d *DatabasesClient) ChangesContinuousBytes(db string, queryReq map[string]
 }
 
 func (d *DatabasesClient) ChangesContinuousRaw(db string, queryReq map[string]string, out chan *DbResult, quit chan struct{}) (chan *DbResult, chan<- struct{}, error) {
+	outCh, _, quitCh, err := d.ChangesContinuousRawWithHeartBeat(db, queryReq, out, nil, quit)
+	return outCh, quitCh, err
+}
+
+func (d *DatabasesClient) ChangesContinuousRawWithHeartBeat(db string, queryReq map[string]string, out chan *DbResult, outHeartbeat chan *HeartBeatResult, quit chan struct{}) (chan *DbResult, chan *HeartBeatResult, chan<- struct{}, error) {
 	if d.Client == nil {
-		return nil, nil, errors.New("You must set an HTTP Client to make requests. Current client is nil")
+		return nil, nil, nil, errors.New("You must set an HTTP Client to make requests. Current client is nil")
 	}
 
 	//take a map of kv and convert them into a "k=v&" string for URL params
@@ -214,7 +230,7 @@ func (d *DatabasesClient) ChangesContinuousRaw(db string, queryReq map[string]st
 	fmt.Printf("Attempting connection to %s://%s/%s/_changes?%s\n", d.protocol, d.Address, db, query)
 	reqHttp, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s://%s/%s/_changes?%s", d.protocol, d.Address, db, query), nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	//set authentication
@@ -226,21 +242,24 @@ func (d *DatabasesClient) ChangesContinuousRaw(db string, queryReq map[string]st
 	//make request
 	httpRes, err := d.Client.Do(reqHttp)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	//create channels if necessary
 	if out == nil {
 		out = make(chan *DbResult, 10000)
 	}
+	if outHeartbeat == nil {
+		outHeartbeat = make(chan *HeartBeatResult, 10000)
+	}
 	if quit == nil {
 		quit = make(chan struct{}, 1)
 	}
 
 	//Launch the listening goroutine that will close http.Body eventually
-	go dbResultHandler(httpRes, out, quit, db)
+	go dbResultHandler(httpRes, out, outHeartbeat, quit, db)
 
-	return out, quit, nil
+	return out, outHeartbeat, quit, nil
 }
 
 func (d *DatabasesClient) Compact(db string) (*OkKoResponse, error) {


### PR DESCRIPTION
Some clients may have the necessity of receiving input from CouchDB even if they are just heartbeat messages.

In this PR we add a new service method to consume `CouchDB` changes feed as the method `ChangesContinuousRaw` does but outputting heartbeats messages as well.

Apart from that, we are now propagating JSON parsing errors to the client (we were omitting them).

